### PR TITLE
Fix 2nd line of channel item label for landscape layouts

### DIFF
--- a/lib/helpers/kodidb.py
+++ b/lib/helpers/kodidb.py
@@ -641,7 +641,7 @@ class KodiDb(object):
             if "channel" in item:
                 properties["channel"] = item["channel"]
                 properties["channelname"] = item["channel"]
-                item["label2"] = item["channel"]
+                item["label2"] = item["title"]
 
             # artwork
             art = item.get("art", {})


### PR DESCRIPTION
Fix for the 2nd line of the label of channel items in landscape layouts to be the title of the current program, rather than repeating the channel name that is already on the 1st line.

Here's a screenshot to show the change
![tv channel landscape widget title](https://user-images.githubusercontent.com/11461240/34140861-a6e53b7a-e4d1-11e7-9102-4991886d4a9a.png)

Note: this was taken with PR https://github.com/marcelveldt/script.skin.helper.widgets/pull/32 applied to fix the issue with thumbnails not showing in landscape layouts.